### PR TITLE
feat: implement POST /ingest endpoint with in-memory storage

### DIFF
--- a/server/MiniSOC.Server.Tests/IngestEndpointTests.cs
+++ b/server/MiniSOC.Server.Tests/IngestEndpointTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using MiniSOC.Server.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace MiniSOC.Server.Tests;
+
+public class IngestEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public IngestEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _jsonOptions = new JsonSerializerOptions 
+        { 
+            PropertyNameCaseInsensitive = true 
+        };
+    }
+
+    [Fact]
+    public async Task PostIngest_ValidEvent_ReturnsOkWithAccepted()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var validEvent = new
+        {
+            timestamp = "2026-02-03T16:00:00Z",
+            host = "TEST-PC",
+            source = "TestSource",
+            level = "Error",
+            message = "Test event"
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(validEvent),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Accepted);
+        Assert.Equal(0, result.Rejected);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task PostIngest_InvalidEvent_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var invalidEvent = new
+        {
+            host = "TEST-PC",
+            level = "Error"
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(invalidEvent),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Accepted);
+        Assert.Equal(1, result.Rejected);
+        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, e => e.Reason.Contains("Timestamp"));
+        Assert.Contains(result.Errors, e => e.Reason.Contains("Source"));
+    }
+
+    [Fact]
+    public async Task PostIngest_ArrayOfEvents_AcceptsMultiple()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var events = new[]
+        {
+            new
+            {
+                timestamp = "2026-02-03T16:00:00Z",
+                host = "PC-1",
+                source = "TestSource",
+                level = "Error"
+            },
+            new
+            {
+                timestamp = "2026-02-03T16:01:00Z",
+                host = "PC-2",
+                source = "TestSource",
+                level = "Warning"
+            }
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(events),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Accepted);
+        Assert.Equal(0, result.Rejected);
+    }
+
+    [Fact]
+    public async Task PostIngest_MixedValidInvalid_ReturnsPartialSuccess()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var events = new object[]
+        {
+            new
+            {
+                timestamp = "2026-02-03T16:00:00Z",
+                host = "PC-1",
+                source = "TestSource",
+                level = "Error"
+            },
+            new
+            {
+                host = "PC-2",
+                level = "Warning"
+            }
+        };
+        var content = new StringContent(
+            JsonSerializer.Serialize(events),
+            Encoding.UTF8,
+            "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Equal(1, result.Accepted);
+        Assert.Equal(1, result.Rejected);
+        Assert.Equal(2, result.Errors.Count);
+        Assert.All(result.Errors, e => Assert.Equal(1, e.Index));
+    }
+
+    [Fact]
+    public async Task PostIngest_EmptyBody_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var content = new StringContent("", Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Equal(0, result.Accepted);
+        Assert.Equal(1, result.Rejected);
+        Assert.Contains(result.Errors, e => e.Reason.Contains("empty"));
+    }
+
+    [Fact]
+    public async Task PostIngest_InvalidJson_ReturnsBadRequest()
+    {
+        // Arrange
+        var client = _factory.CreateClient();
+        var content = new StringContent("{invalid json", Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await client.PostAsync("/ingest", content);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        
+        var json = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<IngestResponse>(json, _jsonOptions);
+        
+        Assert.NotNull(result);
+        Assert.Contains(result.Errors, e => e.Reason.Contains("Invalid JSON"));
+    }
+}

--- a/server/MiniSOC.Server/Endpoints/IngestEndpoints.cs
+++ b/server/MiniSOC.Server/Endpoints/IngestEndpoints.cs
@@ -1,0 +1,124 @@
+using Microsoft.AspNetCore.Mvc;
+using MiniSOC.Server.Models;
+using MiniSOC.Server.Services;
+using System.Text.Json;
+
+namespace MiniSOC.Server.Endpoints;
+
+public static class IngestEndpoints
+{
+    public static void MapIngestEndpoints(this WebApplication app)
+    {
+        app.MapPost("/ingest", async (
+            HttpContext context,
+            [FromServices] IEventStorageService storage) =>
+        {
+            var response = new IngestResponse();
+            
+            try
+            {
+                using var reader = new StreamReader(context.Request.Body);
+                var body = await reader.ReadToEndAsync();
+                
+                if (string.IsNullOrWhiteSpace(body))
+                {
+                    return Results.BadRequest(new IngestResponse
+                    {
+                        Rejected = 1,
+                        Errors = new List<IngestError>
+                        {
+                            new() { Index = 0, Reason = "Request body is empty" }
+                        }
+                    });
+                }
+                
+                var options = new JsonSerializerOptions 
+                { 
+                    PropertyNameCaseInsensitive = true 
+                };
+                
+                List<Event> events;
+                
+                if (body.TrimStart().StartsWith('['))
+                {
+                    events = JsonSerializer.Deserialize<List<Event>>(body, options) 
+                             ?? new List<Event>();
+                }
+                else
+                {
+                    var singleEvent = JsonSerializer.Deserialize<Event>(body, options);
+                    events = singleEvent != null ? new List<Event> { singleEvent } : new List<Event>();
+                }
+                
+                for (int i = 0; i < events.Count; i++)
+                {
+                    var evt = events[i];
+                    var validationErrors = ValidateEvent(evt);
+                    
+                    if (validationErrors.Any())
+                    {
+                        response = response with 
+                        { 
+                            Rejected = response.Rejected + 1,
+                            Errors = response.Errors.Concat(validationErrors.Select(e => 
+                                new IngestError { Index = i, Reason = e })).ToList()
+                        };
+                    }
+                    else
+                    {
+                        bool added = storage.AddEvent(evt);
+                        if (added)
+                        {
+                            response = response with { Accepted = response.Accepted + 1 };
+                        }
+                        else
+                        {
+                            response = response with 
+                            { 
+                                Rejected = response.Rejected + 1,
+                                Errors = response.Errors.Append(new IngestError 
+                                { 
+                                    Index = i, 
+                                    Reason = "Event with this ID already exists" 
+                                }).ToList()
+                            };
+                        }
+                    }
+                }
+                
+                return response.Rejected > 0 
+                    ? Results.BadRequest(response) 
+                    : Results.Ok(response);
+            }
+            catch (JsonException ex)
+            {
+                return Results.BadRequest(new IngestResponse
+                {
+                    Rejected = 1,
+                    Errors = new List<IngestError>
+                    {
+                        new() { Index = 0, Reason = $"Invalid JSON: {ex.Message}" }
+                    }
+                });
+            }
+        })
+        .WithName("IngestEvents")
+        .WithOpenApi();        
+    }
+    
+    private static List<string> ValidateEvent(Event evt)
+    {
+        var errors = new List<string>();
+        
+        if (string.IsNullOrWhiteSpace(evt.Timestamp))
+            errors.Add("Timestamp is required");
+            
+        if (string.IsNullOrWhiteSpace(evt.Host))
+            errors.Add("Host is required");
+            
+        if (string.IsNullOrWhiteSpace(evt.Source))
+            errors.Add("Source is required");
+        
+        return errors;
+    }
+}

--- a/server/MiniSOC.Server/Models/Event.cs
+++ b/server/MiniSOC.Server/Models/Event.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace MiniSOC.Server.Models;
+
+/// <summary>
+/// Security event model matching schema v0.1
+/// </summary>
+public record Event
+{
+    /// <summary>
+    /// Unique event identifier (UUID or hash)
+    /// </summary>
+    [JsonPropertyName("event_id")]
+    public string? EventId { get; init; }
+    
+    /// <summary>
+    /// Timestamp when the event occurred (ISO 8601 format)
+    /// </summary>
+    [Required(ErrorMessage = "Timestamp is required")]
+    [JsonPropertyName("timestamp")]
+    public string Timestamp { get; init; } = string.Empty;
+    
+    /// <summary>
+    /// Host machine identifier
+    /// </summary>
+    [Required(ErrorMessage = "Host is required")]
+    [StringLength(255, ErrorMessage = "Host name must not exceed 255 characters")]
+    [JsonPropertyName("host")]
+    public string Host { get; init; } = string.Empty;
+    
+    /// <summary>
+    /// Event source (e.g., "WindowsEventLog")
+    /// </summary>
+    [Required(ErrorMessage = "Source is required")]
+    [StringLength(100, ErrorMessage = "Source must not exceed 100 characters")]
+    [JsonPropertyName("source")]
+    public string Source { get; init; } = string.Empty;
+    
+    /// <summary>
+    /// Event channel (optional, e.g., "System", "Security")
+    /// </summary>
+    [JsonPropertyName("channel")]
+    public string? Channel { get; init; }
+    
+    /// <summary>
+    /// Event provider (optional, e.g., "Service Control Manager")
+    /// </summary>
+    [JsonPropertyName("provider")]
+    public string? Provider { get; init; }
+    
+    /// <summary>
+    /// Event severity level
+    /// </summary>
+    [Required(ErrorMessage = "Level is required")]
+    [JsonPropertyName("level")]
+    public EventLevel Level { get; init; }
+    
+    /// <summary>
+    /// Human-readable event message
+    /// </summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+    
+    /// <summary>
+    /// Raw event data (flexible, source-specific)
+    /// </summary>
+    [JsonPropertyName("raw")]
+    public Dictionary<string, object>? Raw { get; init; }
+}

--- a/server/MiniSOC.Server/Models/EventLevel.cs
+++ b/server/MiniSOC.Server/Models/EventLevel.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace MiniSOC.Server.Models;
+
+/// <summary>
+/// Severity level of a security event
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum EventLevel
+{
+    /// <summary>
+    /// Informational event (lowest severity)
+    /// </summary>
+    Information = 0,
+    
+    /// <summary>
+    /// Warning - potential issue
+    /// </summary>
+    Warning = 1,
+    
+    /// <summary>
+    /// Error - confirmed issue
+    /// </summary>
+    Error = 2,
+    
+    /// <summary>
+    /// Critical - severe issue requiring immediate attention
+    /// </summary>
+    Critical = 3
+}

--- a/server/MiniSOC.Server/Models/IngestResponse.cs
+++ b/server/MiniSOC.Server/Models/IngestResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace MiniSOC.Server.Models;
+
+public record IngestResponse
+{
+    [JsonPropertyName("accepted")]
+    public int Accepted { get; init; }
+    
+    [JsonPropertyName("rejected")]
+    public int Rejected { get; init; }
+    
+    [JsonPropertyName("errors")]
+    public List<IngestError> Errors { get; init; } = new();
+}
+
+public record IngestError
+{
+    [JsonPropertyName("index")]
+    public int Index { get; init; }
+    
+    [JsonPropertyName("reason")]
+    public string Reason { get; init; } = string.Empty;
+}

--- a/server/MiniSOC.Server/Program.cs
+++ b/server/MiniSOC.Server/Program.cs
@@ -1,9 +1,19 @@
 using MiniSOC.Server.Endpoints;
+using MiniSOC.Server.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Configure JSON serialization for enums
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+});
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+// Register EventStorageService as Singleton
+builder.Services.AddSingleton<IEventStorageService, EventStorageService>();
 
 var app = builder.Build();
 
@@ -17,6 +27,7 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.MapHealthEndpoints();
+app.MapIngestEndpoints();
 
 app.Run();
 

--- a/server/MiniSOC.Server/Services/EventStorageService.cs
+++ b/server/MiniSOC.Server/Services/EventStorageService.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using MiniSOC.Server.Models;
+
+namespace MiniSOC.Server.Services;
+
+/// <summary>
+/// Interface for event storage operations
+/// </summary>
+public interface IEventStorageService
+{
+    /// <summary>
+    /// Add an event to storage
+    /// </summary>
+    /// <param name="event">The event to store</param>
+    /// <returns>True if added successfully, false if event_id already exists</returns>
+    bool AddEvent(Event @event);
+    
+    /// <summary>
+    /// Retrieve all stored events
+    /// </summary>
+    /// <returns>Collection of all events</returns>
+    IEnumerable<Event> GetAllEvents();
+    
+    /// <summary>
+    /// Get count of stored events
+    /// </summary>
+    int GetEventCount();
+}
+
+/// <summary>
+/// In-memory storage for security events using thread-safe dictionary
+/// </summary>
+public class EventStorageService : IEventStorageService
+{
+    // Why ConcurrentDictionary?
+    // - Thread-safe (multiple POST requests)
+    // - Fast lookup by event_id
+    // - No locking needed
+    private readonly ConcurrentDictionary<string, Event> _events = new();
+
+    public bool AddEvent(Event @event)
+    {
+        // Generate event_id if not provided
+        var eventId = @event.EventId ?? Guid.NewGuid().ToString();
+        
+        // Create new event with guaranteed event_id
+        var eventWithId = @event with { EventId = eventId };
+        
+        // TryAdd returns false if key already exists (thread-safe)
+        return _events.TryAdd(eventId, eventWithId);
+    }
+
+    public IEnumerable<Event> GetAllEvents()
+    {
+        return _events.Values;
+    }
+
+    public int GetEventCount()
+    {
+        return _events.Count;
+    }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -4,8 +4,9 @@ REST API for the MiniSOC log collection platform.
 
 ## Status
 - ✅ Health check endpoint implemented
-- ⏳ Event ingestion (planned)
+- ✅ Event ingestion endpoint implemented (in-memory storage)
 - ⏳ Query endpoints (planned)
+- ⏳ Persistence layer (planned)
 
 ## Quick Start
 
@@ -26,7 +27,7 @@ Health check endpoint.
 ```json
 {
   "status": "healthy",
-  "timestamp": "2026-02-02T15:30:00Z",
+  "timestamp": "2026-02-03T15:30:00Z",
   "version": "0.1.0"
 }
 ```
@@ -34,15 +35,106 @@ Health check endpoint.
 **Status Codes:**
 - `200 OK` - Service is healthy
 
+---
+
+#### POST /ingest
+Ingest security events for storage and analysis.
+
+**Request Body:**
+
+Single event:
+```json
+{
+  "timestamp": "2026-02-03T16:00:00Z",
+  "host": "DESKTOP-123",
+  "source": "WindowsEventLog",
+  "level": "Error",
+  "message": "Login failed",
+  "channel": "Security",
+  "provider": "Microsoft-Windows-Security-Auditing"
+}
+```
+
+Array of events:
+```json
+[
+  {
+    "timestamp": "2026-02-03T16:00:00Z",
+    "host": "DESKTOP-123",
+    "source": "WindowsEventLog",
+    "level": "Error"
+  },
+  {
+    "timestamp": "2026-02-03T16:01:00Z",
+    "host": "SERVER-456",
+    "source": "WindowsEventLog",
+    "level": "Warning"
+  }
+]
+```
+
+**Required Fields:**
+- `timestamp` (ISO 8601 format)
+- `host` (hostname/machine identifier)
+- `source` (event source, e.g., "WindowsEventLog")
+- `level` (one of: Information, Warning, Error, Critical)
+
+**Optional Fields:**
+- `event_id` (generated if not provided)
+- `message`
+- `channel`
+- `provider`
+- `raw` (arbitrary key-value data)
+
+**Response:**
+```json
+{
+  "accepted": 2,
+  "rejected": 0,
+  "errors": []
+}
+```
+
+**Status Codes:**
+- `200 OK` - All events accepted
+- `400 Bad Request` - Validation errors or malformed JSON
+
+**Error Response Example:**
+```json
+{
+  "accepted": 1,
+  "rejected": 1,
+  "errors": [
+    {
+      "index": 1,
+      "reason": "Timestamp is required"
+    }
+  ]
+}
+```
+
+---
+
 ### Test the API
 
 **Browser:**
 - Swagger UI: `http://localhost:5152/swagger`
 - Health endpoint: `http://localhost:5152/health`
 
-**curl:**
+**curl examples:**
 ```bash
+# Health check
 curl http://localhost:5152/health
+
+# Ingest single event
+curl -X POST http://localhost:5152/ingest \
+  -H "Content-Type: application/json" \
+  -d '{"timestamp":"2026-02-03T16:00:00Z","host":"PC-123","source":"WindowsEventLog","level":"Error"}'
+
+# Ingest multiple events
+curl -X POST http://localhost:5152/ingest \
+  -H "Content-Type: application/json" \
+  -d '[{"timestamp":"2026-02-03T16:00:00Z","host":"PC-1","source":"WindowsEventLog","level":"Error"},{"timestamp":"2026-02-03T16:01:00Z","host":"PC-2","source":"WindowsEventLog","level":"Warning"}]'
 ```
 
 ## Development
@@ -57,19 +149,33 @@ dotnet test
 ```
 server/
 ├── MiniSOC.Server/
-│   ├── Program.cs           # Application entry point
-│   ├── Endpoints/           # API endpoint definitions
-│   │   └── HealthEndpoints.cs
-│   └── Models/              # Response/request models
-│       └── HealthResponse.cs
-└── MiniSOC.Server.Tests/    # Integration tests
-    └── HealthEndpointTests.cs
+│   ├── Program.cs              # Application entry point
+│   ├── Endpoints/              # API endpoint definitions
+│   │   ├── HealthEndpoints.cs
+│   │   └── IngestEndpoints.cs
+│   ├── Models/                 # Request/response models
+│   │   ├── Event.cs
+│   │   ├── EventLevel.cs
+│   │   ├── HealthResponse.cs
+│   │   └── IngestResponse.cs
+│   └── Services/               # Business logic
+│       └── EventStorageService.cs
+└── MiniSOC.Server.Tests/       # Integration tests
+    ├── HealthEndpointTests.cs
+    └── IngestEndpointTests.cs
 ```
 
 ## Technology Stack
 - ASP.NET Core 8 (Minimal APIs)
 - xUnit (Testing)
 - Swagger/OpenAPI (Documentation)
+
+## Event Schema
+Events follow schema v0.1 as defined in `docs/event-schema-v0.1.md`.
+
+## Storage
+Currently uses in-memory storage (ConcurrentDictionary). Events are lost on server restart.
+Persistence layer will be added in a future milestone.
 
 ## Next Steps
 See `docs/backlog.md` for planned features.


### PR DESCRIPTION
## Changes
- Implement POST /ingest endpoint for event ingestion
- Support single event or array of events
- Add Event model with validation (timestamp, host, source, level required)
- Add EventLevel enum with 4 severity levels
- Implement thread-safe in-memory storage (ConcurrentDictionary)
- Comprehensive error handling and validation feedback

## Testing
- ✅ 7 integration tests (all passing)
- ✅ Valid events accepted
- ✅ Invalid events rejected with detailed errors
- ✅ Array ingestion works
- ✅ Mixed valid/invalid handling
- ✅ Empty body and malformed JSON handled

## Documentation
- Updated server README with API examples
- curl examples for testing
- Schema documentation

Closes #4