### PR TITLE
feat: implement event retrieval with filters

### DIFF
--- a/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
+++ b/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
@@ -166,4 +166,71 @@ public class EventRetrievalTests
         // Cleanup: Remove test database
         File.Delete(testDbPath);
     }
+
+    [Fact]
+    public void GetEvents_WithFilters_ReturnsFilteredEvents()
+    {
+        // Arrange: Create test database with diverse events
+        var testDbPath = "test_filters.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        dbService.Initialize();
+
+        // Add events with different timestamps, levels, and hosts
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-03-18T09:00:00Z",
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Error
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-03-18T10:00:00Z",
+            Host = "PC-2",
+            Source = "Test",
+            Level = EventLevel.Warning
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-03-18T11:00:00Z",
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Information
+        });
+        
+        // Act & Assert: Test different filters
+        
+        // Filter by level
+        var errorEvents = dbService.GetEvents(level: EventLevel.Error);
+        Assert.Equal(1, errorEvents.Count);
+        Assert.Equal(EventLevel.Error, errorEvents[0].Level);
+        
+        // Filter by host
+        var pc1Events = dbService.GetEvents(host: "PC-1");
+        Assert.Equal(2, pc1Events.Count);
+        Assert.All(pc1Events, e => Assert.Equal("PC-1", e.Host));
+        
+        // Filter by time range
+        var timeRangeEvents = dbService.GetEvents(startTime: "2026-03-18T10:00:00Z");
+        Assert.Equal(2, timeRangeEvents.Count);
+        
+        // Combined filters
+        var combinedEvents = dbService.GetEvents(level: EventLevel.Error, host: "PC-1");
+        Assert.Equal(1, combinedEvents.Count);
+        
+        // Cleanup
+        File.Delete(testDbPath);
+    }
 }

--- a/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
+++ b/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
@@ -1,0 +1,169 @@
+using MiniSOC.Server.Services;
+using MiniSOC.Server.Models;
+using Microsoft.Extensions.Configuration;
+using System.Text.Json;
+
+namespace MiniSOC.Server.Tests;
+
+/// <summary>
+/// Tests for event retrieval from SQLite database
+/// </summary>
+public class EventRetrievalTests
+{
+    [Fact]
+    public void GetAllEvents_ReturnsStoredEvents()
+    {
+        // Arrange: Set up test database with three different event types
+        var testDbPath = "test_retrieval.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        dbService.Initialize();
+
+        // Event 1: Minimal event with required fields only
+        var event1 = new Event
+        {
+            Timestamp = "2026-03-18T10:00:00Z",
+            Host = "TEST-PC-1",
+            Source = "TestSource",
+            Level = EventLevel.Error,
+            Message = "First test event"
+        };
+
+        // Event 2: Event with nullable field (Channel)
+        var event2 = new Event
+        {
+            Timestamp = "2026-03-18T10:01:00Z",
+            Host = "TEST-PC-2",
+            Source = "TestSource",
+            Level = EventLevel.Warning,
+            Message = "Second test event",
+            Channel = "Security"
+        };
+
+        // Event 3: Event with Provider and Raw dictionary
+        var event3 = new Event
+        {
+            Timestamp = "2026-03-18T10:02:00Z",
+            Host = "TEST-PC-3",
+            Source = "TestSource",
+            Level = EventLevel.Information,
+            Message = "Third test event",
+            Provider = "TestProvider",
+            Raw = new Dictionary<string, object>
+            {
+                ["testKey"] = "testValue",
+                ["eventRecordId"] = 12345
+            }
+        };
+
+        dbService.AddEvent(event1);
+        dbService.AddEvent(event2);
+        dbService.AddEvent(event3);
+        
+        // Act: Retrieve all events from database
+        var events = dbService.GetAllEvents();
+        
+        // Assert: Verify correct count and data mapping
+        Assert.Equal(3, events.Count);
+
+        // Verify Event 1: Basic field mapping
+        Assert.Equal("TEST-PC-1", events[0].Host);
+        Assert.Equal("TestSource", events[0].Source);
+        Assert.Equal(EventLevel.Error, events[0].Level);
+        Assert.Equal("First test event", events[0].Message);
+        Assert.Equal("2026-03-18T10:00:00Z", events[0].Timestamp);
+
+        // Verify Event 2: Nullable field handling
+        Assert.Equal("TEST-PC-2", events[1].Host);
+        Assert.Equal(EventLevel.Warning, events[1].Level);
+        Assert.Equal("Security", events[1].Channel);
+        Assert.Null(events[1].Provider);
+
+        // Verify Event 3: Dictionary deserialization from JSON
+        Assert.Equal("TEST-PC-3", events[2].Host);
+        Assert.Equal(EventLevel.Information, events[2].Level);
+        Assert.Equal("TestProvider", events[2].Provider);
+        Assert.NotNull(events[2].Raw);
+        Assert.Equal(2, events[2].Raw.Count);
+        Assert.Equal("testValue", ((JsonElement)events[2].Raw["testKey"]).GetString());
+        Assert.Equal(12345, ((JsonElement)events[2].Raw["eventRecordId"]).GetInt32());
+        
+        // Cleanup: Remove test database
+        File.Delete(testDbPath);
+    }
+    
+    [Fact]
+    public void GetEventCount_ReturnsCorrectCount()
+    {
+        // Arrange: Set up test database with three events
+        var testDbPath = "test_count.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        dbService.Initialize();
+
+        var event1 = new Event
+        {
+            Timestamp = "2026-03-18T10:00:00Z",
+            Host = "TEST-PC-1",
+            Source = "TestSource",
+            Level = EventLevel.Error,
+            Message = "First test event"
+        };
+
+        var event2 = new Event
+        {
+            Timestamp = "2026-03-18T10:01:00Z",
+            Host = "TEST-PC-2",
+            Source = "TestSource",
+            Level = EventLevel.Warning,
+            Message = "Second test event",
+            Channel = "Security"
+        };
+
+        var event3 = new Event
+        {
+            Timestamp = "2026-03-18T10:02:00Z",
+            Host = "TEST-PC-3",
+            Source = "TestSource",
+            Level = EventLevel.Information,
+            Message = "Third test event",
+            Provider = "TestProvider",
+            Raw = new Dictionary<string, object>
+            {
+                ["testKey"] = "testValue",
+                ["eventRecordId"] = 12345
+            }
+        };
+
+        dbService.AddEvent(event1);
+        dbService.AddEvent(event2);
+        dbService.AddEvent(event3);
+        
+        // Act: Get event count from database
+        var count = dbService.GetEventCount();
+        
+        // Assert: Verify correct count
+        Assert.Equal(3, count);
+        
+        // Cleanup: Remove test database
+        File.Delete(testDbPath);
+    }
+}

--- a/server/MiniSOC.Server/Endpoints/EventsEndpoints.cs
+++ b/server/MiniSOC.Server/Endpoints/EventsEndpoints.cs
@@ -1,0 +1,16 @@
+using MiniSOC.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MiniSOC.Server.Endpoints;
+
+public static class EventsEndpoints
+{
+    public static void MapEventsEndpoints(this WebApplication app)
+    {
+        app.MapGet("/events", ([FromServices] IDatabaseService database) =>
+        {
+            var events = database.GetAllEvents();
+            return Results.Ok(events);
+        });
+    }
+}

--- a/server/MiniSOC.Server/Endpoints/EventsEndpoints.cs
+++ b/server/MiniSOC.Server/Endpoints/EventsEndpoints.cs
@@ -1,5 +1,6 @@
 using MiniSOC.Server.Services;
 using Microsoft.AspNetCore.Mvc;
+using MiniSOC.Server.Models;  
 
 namespace MiniSOC.Server.Endpoints;
 
@@ -7,10 +8,15 @@ public static class EventsEndpoints
 {
     public static void MapEventsEndpoints(this WebApplication app)
     {
-        app.MapGet("/events", ([FromServices] IDatabaseService database) =>
-        {
-            var events = database.GetAllEvents();
-            return Results.Ok(events);
-        });
+        app.MapGet("/events", (
+        [FromServices] IDatabaseService database,
+        string? startTime,
+        string? endTime,
+        EventLevel? level,
+        string? host) =>
+    {
+        var events = database.GetEvents(startTime, endTime, level, host);
+        return Results.Ok(events);
+    });
     }
 }

--- a/server/MiniSOC.Server/Program.cs
+++ b/server/MiniSOC.Server/Program.cs
@@ -34,6 +34,7 @@ app.UseHttpsRedirection();
 
 app.MapHealthEndpoints();
 app.MapIngestEndpoints();
+app.MapEventsEndpoints();
 
 app.Run();
 

--- a/server/MiniSOC.Server/Services/IDatabaseService.cs
+++ b/server/MiniSOC.Server/Services/IDatabaseService.cs
@@ -14,4 +14,11 @@ public interface IDatabaseService
     List<Event> GetAllEvents();
 
     int GetEventCount();
+
+    List<Event> GetEvents(
+    string? startTime = null,
+    string? endTime = null,
+    EventLevel? level = null,
+    string? host = null
+);
 }

--- a/server/MiniSOC.Server/Services/IDatabaseService.cs
+++ b/server/MiniSOC.Server/Services/IDatabaseService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using MiniSOC.Server.Models;
+using System.Collections.Generic;
 
 namespace MiniSOC.Server.Services;
 
@@ -9,4 +10,8 @@ public interface IDatabaseService
     SqliteConnection GetConnection();
 
     bool AddEvent(Event @event);
+
+    List<Event> GetAllEvents();
+
+    int GetEventCount();
 }

--- a/server/MiniSOC.Server/Services/SqliteDatabaseService.cs
+++ b/server/MiniSOC.Server/Services/SqliteDatabaseService.cs
@@ -92,7 +92,6 @@ public class SqliteDatabaseService : IDatabaseService
         }
     }
 
-    // Read - refactor into new file if queries add up
     public int GetEventCount()
     {
         using var connection = GetConnection();
@@ -117,6 +116,7 @@ public class SqliteDatabaseService : IDatabaseService
 
         while (reader.Read())
         {
+            // Map database row to Event object
             var event_id = reader["event_id"].ToString();
             var timestamp = reader["timestamp"].ToString();
             var host = reader["host"].ToString();
@@ -127,7 +127,7 @@ public class SqliteDatabaseService : IDatabaseService
             var level = Enum.Parse<EventLevel>(levelString);
             var message = reader["message"] == DBNull.Value ? null : reader["message"].ToString();
             var rawJson = reader["raw"] == DBNull.Value ? null : reader["raw"].ToString();
-            var raw = rawJson != null ? JsonSerializer.Deserialize<Dictionary<string, object>>(rawJson) :null;
+            var raw = rawJson != null ? JsonSerializer.Deserialize<Dictionary<string, object>>(rawJson) : null;
         
             var evt = new Event
             {
@@ -144,5 +144,85 @@ public class SqliteDatabaseService : IDatabaseService
             events.Add(evt);
         }
         return events;        
+    }
+
+    public List<Event> GetEvents(
+        string? startTime = null,
+        string? endTime = null,
+        EventLevel? level = null,
+        string? host = null)
+    {
+        var events = new List<Event>();
+        
+        using var connection = GetConnection();
+        connection.Open();
+        
+        var command = connection.CreateCommand();
+        
+        // Build WHERE clause dynamically based on provided filters
+        var conditions = new List<string>();
+        
+        if (startTime != null)
+        {
+            conditions.Add("timestamp >= $startTime");
+            command.Parameters.AddWithValue("$startTime", startTime);
+        }
+
+        if (endTime != null)
+        {
+            conditions.Add("timestamp <= $endTime");
+            command.Parameters.AddWithValue("$endTime", endTime);
+        }
+
+        if (level != null)
+        {
+            conditions.Add("level = $level");
+            command.Parameters.AddWithValue("$level", level.ToString());
+        }
+
+        if (host != null)
+        {
+            conditions.Add("host = $host");
+            command.Parameters.AddWithValue("$host", host);
+        }
+
+        var whereClause = conditions.Count > 0 
+            ? "WHERE " + string.Join(" AND ", conditions)
+            : "";
+        
+        command.CommandText = $"SELECT * FROM Events {whereClause}";
+        
+        using var reader = command.ExecuteReader();
+
+        while (reader.Read())
+        {
+            // Map database row to Event object (using unique variable names to avoid parameter shadowing)
+            var eventIdValue = reader["event_id"].ToString();
+            var timestampValue = reader["timestamp"].ToString();
+            var hostValue = reader["host"].ToString();
+            var sourceValue = reader["source"].ToString();
+            var channelValue = reader["channel"] == DBNull.Value ? null : reader["channel"].ToString();
+            var providerValue = reader["provider"] == DBNull.Value ? null : reader["provider"].ToString();
+            var levelStringValue = reader["level"].ToString();
+            var levelValue = Enum.Parse<EventLevel>(levelStringValue);
+            var messageValue = reader["message"] == DBNull.Value ? null : reader["message"].ToString();
+            var rawJsonValue = reader["raw"] == DBNull.Value ? null : reader["raw"].ToString();
+            var rawValue = rawJsonValue != null ? JsonSerializer.Deserialize<Dictionary<string, object>>(rawJsonValue) : null;
+        
+            var evt = new Event
+            {
+                EventId = eventIdValue,
+                Timestamp = timestampValue,
+                Host = hostValue,
+                Source = sourceValue,
+                Channel = channelValue,
+                Provider = providerValue,
+                Level = levelValue,
+                Message = messageValue,
+                Raw = rawValue
+            };
+            events.Add(evt);
+        }        
+        return events;
     }
 }

--- a/server/MiniSOC.Server/Services/SqliteDatabaseService.cs
+++ b/server/MiniSOC.Server/Services/SqliteDatabaseService.cs
@@ -91,4 +91,58 @@ public class SqliteDatabaseService : IDatabaseService
             return false;
         }
     }
+
+    // Read - refactor into new file if queries add up
+    public int GetEventCount()
+    {
+        using var connection = GetConnection();
+        connection.Open();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Events";
+        var count = (long)command.ExecuteScalar();
+        return (int)count;
+    }
+
+    public List<Event> GetAllEvents()
+    {
+        var events = new List<Event>();
+
+        using var connection = GetConnection();
+        connection.Open();
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM Events";
+        using var reader = command.ExecuteReader();
+
+        while (reader.Read())
+        {
+            var event_id = reader["event_id"].ToString();
+            var timestamp = reader["timestamp"].ToString();
+            var host = reader["host"].ToString();
+            var source = reader["source"].ToString();
+            var channel = reader["channel"] == DBNull.Value ? null : reader["channel"].ToString();
+            var provider = reader["provider"] == DBNull.Value ? null : reader["provider"].ToString();
+            var levelString = reader["level"].ToString();
+            var level = Enum.Parse<EventLevel>(levelString);
+            var message = reader["message"] == DBNull.Value ? null : reader["message"].ToString();
+            var rawJson = reader["raw"] == DBNull.Value ? null : reader["raw"].ToString();
+            var raw = rawJson != null ? JsonSerializer.Deserialize<Dictionary<string, object>>(rawJson) :null;
+        
+            var evt = new Event
+            {
+                EventId = event_id,
+                Timestamp = timestamp,
+                Host = host,
+                Source = source,
+                Channel = channel,
+                Provider = provider,
+                Level = level,
+                Message = message,
+                Raw = raw
+            };
+            events.Add(evt);
+        }
+        return events;        
+    }
 }


### PR DESCRIPTION
## Changes
Implements Issue #12: Event Retrieval with query filters

### Features
**Basic Retrieval:**
- `GetAllEvents()` - retrieve all events from database
- `GetEventCount()` - get total event count
- `GET /events` endpoint - returns events as JSON

**Advanced Filtering:**
- `GetEvents()` - retrieve events with optional filters
- Query parameters: `startTime`, `endTime`, `level`, `host`
- Dynamic WHERE clause construction
- Filter combinations supported (e.g., `?level=Error&host=PC-1`)

### Implementation Details
**Database Mapping:**
- Complete row-to-Event object mapping
- Nullable field handling (DBNull.Value → null)
- EventLevel enum deserialization (string → enum)
- Raw dictionary deserialization (JSON string → Dictionary)

**Query Filters:**
- Time range: `timestamp >= startTime AND timestamp <= endTime`
- Severity: `level = Error|Warning|Information|Critical`
- Host: `host = hostname`
- All filters use parameterized queries (SQL injection prevention)

**Endpoint:**
- `GET /events` - all events
- `GET /events?level=Error` - filter by severity
- `GET /events?host=PC-1` - filter by host
- `GET /events?startTime=2026-03-18T10:00:00Z` - time range
- `GET /events?level=Error&host=PC-1` - combined filters

### Testing
**Automated Tests (13 total, all passing):**
- `GetAllEvents_ReturnsStoredEvents` - comprehensive mapping validation
- `GetEventCount_ReturnsCorrectCount` - count accuracy
- `GetEvents_WithFilters_ReturnsFilteredEvents` - all filter combinations

**Manual Testing:**
- ✅ GET /events returns all events
- ✅ Level filter works (Error, Warning, Information)
- ✅ Host filter works
- ✅ Time range filter works (startTime, endTime)
- ✅ Combined filters work (level + host)
- ✅ Swagger UI functional

### Technical Notes
- Two commits: basic retrieval + filter feature
- Variable naming adjusted in GetEvents() to avoid parameter shadowing
- JsonElement handling for dictionary deserialization
- WHERE clause built dynamically only for non-null parameters

Closes #12