### PR TITLE
feat: add GET /metrics endpoint with event count, by level and by host

### DIFF
--- a/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
+++ b/server/MiniSOC.Server.Tests/EventRetrievalTests.cs
@@ -219,7 +219,7 @@ public class EventRetrievalTests
             Provider = "TestProvider"
         });
         
-        // Act & Assert: Test different filters
+        // Act & Assert: Tst different filters
         
         // Filter by level
         var errorEvents = dbService.GetEvents(level: EventLevel.Error);

--- a/server/MiniSOC.Server.Tests/MetricsTests.cs
+++ b/server/MiniSOC.Server.Tests/MetricsTests.cs
@@ -1,0 +1,74 @@
+using MiniSOC.Server.Services;
+using MiniSOC.Server.Models;
+using Microsoft.Extensions.Configuration;
+using System.Text.Json;
+
+namespace MiniSOC.Server.Tests;
+
+/// <summary>
+/// Tests for metrics
+/// </summary>
+public class MetricsTests
+{
+    [Fact]
+
+    public void GetMetrics_ReturnsAggregatedData()
+    {
+        // Arrange: Create test database with diverse events
+        var testDbPath = "test_metrics.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        var metricsService = new SqliteMetricsService(dbService);
+        dbService.Initialize();
+
+        // Add events with different levels and hosts
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-04-14T09:00:00Z",
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Warning
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-04-14T10:00:00Z",
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Information
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = "2026-04-14T11:00:00Z",
+            Host = "PC-2",
+            Source = "Test",
+            Level = EventLevel.Warning
+        });
+
+        // Act & Assert
+        var countDB = dbService.GetEventCount();
+        var countMetrics = metricsService.GetEventCount();
+        Assert.Equal(countDB, countMetrics);
+
+        var levels = metricsService.GetEventsByLevel();
+        Assert.Equal(2, levels["Warning"]);
+        Assert.Equal(1, levels["Information"]);
+
+        var hosts = metricsService.GetEventsByHost();
+        Assert.Equal(2, hosts["PC-1"]);
+        Assert.Equal(1, hosts["PC-2"]);
+
+        // Cleanup
+        File.Delete(testDbPath);
+    }
+}

--- a/server/MiniSOC.Server/Endpoints/MetricsEndpoints.cs
+++ b/server/MiniSOC.Server/Endpoints/MetricsEndpoints.cs
@@ -1,0 +1,27 @@
+using MiniSOC.Server.Services;
+using Microsoft.AspNetCore.Mvc;
+using MiniSOC.Server.Models;  
+
+namespace MiniSOC.Server.Endpoints;
+
+public static class MetricsEndpoints
+{
+    public static void MapMetricsEndpoints(this WebApplication app)
+    {
+        app.MapGet("/metrics", (
+        [FromServices] IMetricsService metrics) =>
+        {
+            var count = metrics.GetEventCount();
+            var levels = metrics.GetEventsByLevel();
+            var hosts = metrics.GetEventsByHost();
+
+            return Results.Ok(new
+            {
+                event_count = count,
+                by_level = levels,
+                by_host = hosts
+            });
+        });
+
+    }
+}

--- a/server/MiniSOC.Server/Program.cs
+++ b/server/MiniSOC.Server/Program.cs
@@ -12,6 +12,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<IDatabaseService, SqliteDatabaseService>();
+builder.Services.AddSingleton<IMetricsService, SqliteMetricsService>();
 
 var app = builder.Build();
 
@@ -34,6 +35,7 @@ app.UseHttpsRedirection();
 app.MapHealthEndpoints();
 app.MapIngestEndpoints();
 app.MapEventsEndpoints();
+app.MapMetricsEndpoints();
 
 app.Run();
 

--- a/server/MiniSOC.Server/Services/IMetricsService.cs
+++ b/server/MiniSOC.Server/Services/IMetricsService.cs
@@ -1,0 +1,8 @@
+namespace MiniSOC.Server.Services;
+
+public interface IMetricsService
+{
+    int GetEventCount();
+    Dictionary<string, int> GetEventsByLevel();
+    Dictionary<string, int> GetEventsByHost();
+}

--- a/server/MiniSOC.Server/Services/SqliteMetricsService.cs
+++ b/server/MiniSOC.Server/Services/SqliteMetricsService.cs
@@ -1,0 +1,63 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration; 
+using MiniSOC.Server.Models;
+using System.Text.Json;
+
+namespace MiniSOC.Server.Services;
+
+/// <summary>
+/// Service for metrics used in dashboard
+/// </summary>
+/// 
+public class SqliteMetricsService : IMetricsService
+{
+    private readonly IDatabaseService _database;
+
+    public SqliteMetricsService(IDatabaseService database)
+    {
+        _database = database;
+    }
+
+    public int GetEventCount()
+    {
+        return _database.GetEventCount();
+    }
+
+    public Dictionary<string, int> GetEventsByLevel()
+    {
+        var result = new Dictionary<string, int>();
+
+        using var connection = _database.GetConnection();
+        connection.Open();
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT level, COUNT(*) FROM Events GROUP BY level";
+        using var reader = command.ExecuteReader();
+
+        while (reader.Read())
+        {
+            var level = reader["level"].ToString();
+            var count = (long)reader[1]; 
+            result[level] = (int)count;
+        }
+        return result;
+    }
+
+    public Dictionary<string, int> GetEventsByHost()
+    {
+        var result = new Dictionary<string, int>();
+
+        using var connection = _database.GetConnection();
+        connection.Open();
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT host, COUNT(*) FROM Events GROUP BY host";
+        using var reader = command.ExecuteReader();
+
+        while (reader.Read())
+        {
+            var host = reader["host"].ToString();
+            var count = (long)reader[1]; 
+            result[host] = (int)count;
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Adds new GET /metrics endpoint returning aggregated event statistics.

- Returns total event count
- Returns breakdown by level (dictionary)
- Returns breakdown by host (dictionary)
- New IMetricsService interface and SqliteMetricsService implementation
- 1 new test case added

Closes #19