### PR TITLE
feat: add trend data to GET /metrics

### DIFF
--- a/server/MiniSOC.Server.Tests/MetricsTests.cs
+++ b/server/MiniSOC.Server.Tests/MetricsTests.cs
@@ -71,4 +71,105 @@ public class MetricsTests
         // Cleanup
         File.Delete(testDbPath);
     }
+
+    [Fact]
+
+    public void GetMetrics_24h()
+    {
+        // Arrange: Create test database with diverse events
+        var testDbPath = "test_metrics_24h.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        var metricsService = new SqliteMetricsService(dbService);
+        dbService.Initialize();
+
+        //Add events with different timestamps and some with same timestamp
+        var timestamp1 = DateTime.UtcNow.AddMinutes(-30).ToString("yyyy-MM-ddTHH:mm:ssZ");
+        var timestamp2 = DateTime.UtcNow.AddHours(-3).ToString("yyyy-MM-ddTHH:mm:ssZ");
+        dbService.AddEvent(new Event
+        {
+            Timestamp = timestamp1,
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Warning
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = timestamp1,
+            Host = "PC-2",
+            Source = "Test",
+            Level = EventLevel.Error
+        });
+
+        dbService.AddEvent(new Event
+        {
+            Timestamp = timestamp2,
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Information
+        });
+
+        // Act & Assert
+        var events = metricsService.GetEventsLast24h();
+        Assert.Equal(24, events.Count);
+
+        var expectedHour1 = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 
+            DateTime.UtcNow.Day, DateTime.UtcNow.Hour, 0, 0, DateTimeKind.Utc).AddHours(-1);
+        var bucket1 = events.First(b => b.Time == expectedHour1);
+        Assert.Equal(2, bucket1.Count);
+
+        var expectedHour2 = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 
+            DateTime.UtcNow.Day, DateTime.UtcNow.Hour, 0, 0, DateTimeKind.Utc).AddHours(-3);
+        var bucket2 = events.First(b => b.Time == expectedHour2);
+        Assert.Equal(1, bucket2.Count);
+    }
+
+    [Fact]
+
+    public void GetMetrics_7d()
+    {
+        // Arrange: Create test database with diverse events
+        var testDbPath = "test_metrics_7d.db";
+        if (File.Exists(testDbPath))
+            File.Delete(testDbPath);
+        
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["ConnectionStrings:EventsDatabase"] = $"Data Source={testDbPath}"
+            })
+            .Build();
+
+        var dbService = new SqliteDatabaseService(config);
+        var metricsService = new SqliteMetricsService(dbService);
+        dbService.Initialize();
+
+        //Add events with different timestamps and some with same timestamp
+        var timestamp = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-dd");
+        dbService.AddEvent(new Event
+        {
+            Timestamp = timestamp,
+            Host = "PC-1",
+            Source = "Test",
+            Level = EventLevel.Warning
+        });
+
+        //Act & Assert
+        var events = metricsService.GetEventsLast7d();
+        Assert.Equal(7, events.Count);
+
+        var expectedDay = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, 0, 0, 0).AddDays(-1);
+        var bucket = events.First(b => b.Time == expectedDay);
+        Assert.Equal(1, bucket.Count);
+    }
 }

--- a/server/MiniSOC.Server/Endpoints/MetricsEndpoints.cs
+++ b/server/MiniSOC.Server/Endpoints/MetricsEndpoints.cs
@@ -14,12 +14,18 @@ public static class MetricsEndpoints
             var count = metrics.GetEventCount();
             var levels = metrics.GetEventsByLevel();
             var hosts = metrics.GetEventsByHost();
+            var hours = metrics.GetEventsLast24h();
+            var days = metrics.GetEventsLast7d();
 
             return Results.Ok(new
             {
                 event_count = count,
                 by_level = levels,
-                by_host = hosts
+                by_host = hosts,
+                trend = new {
+                    last_24h = hours,
+                    last_7d = days
+                }
             });
         });
 

--- a/server/MiniSOC.Server/Models/TrendBucket.cs
+++ b/server/MiniSOC.Server/Models/TrendBucket.cs
@@ -1,0 +1,1 @@
+public record TrendBucket(DateTime Time, int Count);

--- a/server/MiniSOC.Server/Services/IMetricsService.cs
+++ b/server/MiniSOC.Server/Services/IMetricsService.cs
@@ -5,4 +5,7 @@ public interface IMetricsService
     int GetEventCount();
     Dictionary<string, int> GetEventsByLevel();
     Dictionary<string, int> GetEventsByHost();
+
+    List<TrendBucket> GetEventsLast24h();
+    List<TrendBucket> GetEventsLast7d();
 }

--- a/server/MiniSOC.Server/Services/SqliteMetricsService.cs
+++ b/server/MiniSOC.Server/Services/SqliteMetricsService.cs
@@ -60,4 +60,82 @@ public class SqliteMetricsService : IMetricsService
         }
         return result;
     }
+
+    public List<TrendBucket> GetEventsLast24h()
+    {
+        var result = new List<TrendBucket>();
+        var dict = new Dictionary<string, int>();
+
+        var now = DateTime.UtcNow;
+        var end = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(1);
+        var start = end.AddHours(-24);
+        
+        using var connection = _database.GetConnection();
+        connection.Open();
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT strftime('%Y-%m-%dT%H:00:00Z', timestamp) AS bucket, COUNT(*) FROM Events WHERE timestamp >= $start AND timestamp <= $end GROUP BY bucket";
+        command.Parameters.AddWithValue("$start", start.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        command.Parameters.AddWithValue("$end", end.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        using var reader = command.ExecuteReader();
+        
+        while (reader.Read())
+        {
+            var timeString = reader["bucket"].ToString();
+            var count = (int)(long)reader[1];
+            dict[timeString] = count;
+        }
+
+        while (start < end)
+        {
+            if (dict.ContainsKey(start.ToString("yyyy-MM-ddTHH:00:00Z")))
+            {
+                result.Add(new TrendBucket(start, dict[start.ToString("yyyy-MM-ddTHH:00:00Z")]));
+            }
+            else
+            {
+                result.Add(new TrendBucket(start, 0));
+            }
+            start = start.AddHours(1);
+        }
+        return result;
+    }
+
+        public List<TrendBucket> GetEventsLast7d()
+    {
+        var result = new List<TrendBucket>();
+        var dict = new Dictionary<string, int>();
+
+        var now = DateTime.UtcNow;
+        var end = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, DateTimeKind.Utc);
+        var start = end.AddDays(-7);
+        
+        using var connection = _database.GetConnection();
+        connection.Open();
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT strftime('%Y-%m-%d', timestamp) AS bucket, COUNT(*) FROM Events WHERE timestamp >= $start AND timestamp <= $end GROUP BY bucket";
+        command.Parameters.AddWithValue("$start", start.ToString("yyyy-MM-dd"));
+        command.Parameters.AddWithValue("$end", end.ToString("yyyy-MM-dd"));
+        using var reader = command.ExecuteReader();
+        
+        while (reader.Read())
+        {
+            var timeString = reader["bucket"].ToString();
+            var count = (int)(long)reader[1];
+            dict[timeString] = count;
+        }
+
+        while (start < end)
+        {
+            if (dict.ContainsKey(start.ToString("yyyy-MM-dd")))
+            {
+                result.Add(new TrendBucket(start, dict[start.ToString("yyyy-MM-dd")]));
+            }
+            else
+            {
+                result.Add(new TrendBucket(start, 0));
+            }
+            start = start.AddDays(1);
+        }
+        return result;
+    }
 }


### PR DESCRIPTION
Extends GET /metrics with trend data for the last 24 hours and 7 days.

- last_24h: 24 hourly buckets, time = start of bucket (UTC)
- last_7d: 7 daily buckets, time = start of bucket (UTC)
- Empty buckets return count: 0
- New IMetricsService methods and SqliteMetricsService implementation
- New TrendBucket record in Models/
- 2 new test cases added

Closes #20 