### PR TITLE
feat: add charts to UI dashboard

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,5 +1,6 @@
 document.addEventListener("DOMContentLoaded", () => {
     loadEvents(); 
+    loadMetrics();
     
     document.getElementById("filter-btn").addEventListener("click", () => {
         const level = document.getElementById("levels").value;
@@ -32,4 +33,124 @@ async function loadEvents(level, provider, timestart, timeend) {
         row.insertCell().textContent = event.source;
         row.insertCell().textContent = event.message;
     }
+}
+
+async function loadMetrics() {
+    const response = await fetch('http://localhost:5152/metrics');
+    const metrics = await response.json();
+
+    //By level chart
+    const levelData = metrics.by_level;
+    const llabels = Object.keys(levelData);
+    const ldata = Object.values(levelData);
+
+    const levelColors = {
+        "Error": "#ff6b6b",
+        "Warning": "#ffa94d",
+        "Information": "#74c0fc"
+    };
+    const colors = llabels.map(label => levelColors[label] ?? "#888");
+
+    new Chart(document.getElementById("clevel"), {
+        type: "bar",
+        data: {
+            labels: llabels,
+            datasets: [{
+                label: "Events by Level",
+                data: ldata,
+                backgroundColor: colors
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    ticks: {
+                        stepSize: 1
+                    }
+                }
+            }
+        }
+    });
+
+    // By host chart
+    const hostData = metrics.by_host;
+    const hlabels = Object.keys(hostData);
+    const hdata = Object.values(hostData);
+
+    new Chart(document.getElementById("chost"), {
+        type: "bar",
+        data: {
+            labels: hlabels,
+            datasets: [{
+                label: "Events by Host",
+                data: hdata,
+                backgroundColor: "#69db7c"
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    ticks: {
+                        stepSize: 1
+                    }
+                }
+            }
+        }
+    });
+
+    // Last 24 hours chart
+    const hoursAllData = metrics.trend.last_24h;
+    const hoursLabels = hoursAllData.map(bucket => bucket.time.substring(11, 16));
+    const hoursData = hoursAllData.map(bucket => bucket.count);
+
+    new Chart(document.getElementById("c24h"), {
+        type: "line",
+        data: {
+            labels: hoursLabels,
+            datasets: [{
+                label: "Events of last 24 hours",
+                data: hoursData,
+                borderColor: "#ffa94d",
+                backgroundColor: "transparent"
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    min: 0,
+                    ticks: {
+                        stepSize: 1
+                    }
+                }
+            }
+        }
+    })
+
+    // Last 7 days chart
+    const daysAllData = metrics.trend.last_7d;
+    const daysLabels = daysAllData.map(bucket => bucket.time.substring(0, 10));
+    const daysData = daysAllData.map(bucket => bucket.count);
+
+    new Chart(document.getElementById("c7d"), {
+        type: "line",
+        data: {
+            labels: daysLabels,
+            datasets: [{
+                label: "Events of last 7 days",
+                data: daysData,
+                borderColor: "#da77f2",
+                backgroundColor: "transparent"
+            }]
+        },
+        options: {
+            scales: {
+                y: {
+                    min: 0,
+                    ticks: {
+                        stepSize: 1
+                    }
+                }
+            }
+        }
+    })
 }

--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,12 @@
                 <tbody id="events-body"></tbody>
             </table>
         </div>
+        <div id="events-charts">
+            <canvas id="clevel"></canvas>
+            <canvas id="chost"></canvas>
+            <canvas id="c24h"></canvas>
+            <canvas id="c7d"></canvas>
+        </div>
         <footer>
 
         </footer>

--- a/web/style.css
+++ b/web/style.css
@@ -69,3 +69,15 @@ footer {
     font-size: 0.75rem;
     text-align: center;
 }
+
+#events-charts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+#events-charts canvas {
+    max-width: 400px;
+    max-height: 300px;
+}


### PR DESCRIPTION
Adds Chart.js visualizations to the dashboard using GET /metrics.

- Bar chart for events by level with level-specific colors
- Bar chart for events by host
- Line chart for last 24 hours trend
- Line chart for last 7 days trend
- Y-axis limited to integers with min 0
- Timestamps truncated for readability on X-axis

Closes #27 