### PR TITLE
refactor: inject DateTime into GetEventsLast24h and GetEventsLast7d

### DIFF
--- a/server/MiniSOC.Server.Tests/MetricsTests.cs
+++ b/server/MiniSOC.Server.Tests/MetricsTests.cs
@@ -90,7 +90,7 @@ public class MetricsTests
         dbService.Initialize();
 
         //Add events with different timestamps and some with same timestamp
-        var now = DateTime.UtcNow;
+        var now = new DateTime(2026, 4, 15, 12, 0, 0, DateTimeKind.Utc);
         var timestamp1 = now.AddMinutes(-30).ToString("yyyy-MM-ddTHH:mm:ssZ");
         var timestamp2 = now.AddHours(-3).ToString("yyyy-MM-ddTHH:mm:ssZ");
 
@@ -119,7 +119,7 @@ public class MetricsTests
         });
 
         // Act & Assert
-        var events = metricsService.GetEventsLast24h();
+        var events = metricsService.GetEventsLast24h(now);
         Assert.Equal(24, events.Count);
 
         var expectedHour1 = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(-1);
@@ -151,7 +151,8 @@ public class MetricsTests
         dbService.Initialize();
 
         //Add events with different timestamps and some with same timestamp
-        var timestamp = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-dd");
+        var now = new DateTime(2026, 4, 15, 12, 0, 0, DateTimeKind.Utc);
+        var timestamp = now.AddDays(-1).ToString("yyyy-MM-dd");
         dbService.AddEvent(new Event
         {
             Timestamp = timestamp,
@@ -161,10 +162,10 @@ public class MetricsTests
         });
 
         //Act & Assert
-        var events = metricsService.GetEventsLast7d();
+        var events = metricsService.GetEventsLast7d(now);
         Assert.Equal(7, events.Count);
 
-        var expectedDay = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, 0, 0, 0).AddDays(-1);
+        var expectedDay = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, DateTimeKind.Utc).AddDays(-1);
         var bucket = events.First(b => b.Time == expectedDay);
         Assert.Equal(1, bucket.Count);
     }

--- a/server/MiniSOC.Server/Services/IMetricsService.cs
+++ b/server/MiniSOC.Server/Services/IMetricsService.cs
@@ -25,10 +25,10 @@ public interface IMetricsService
     /// <summary>
     /// Returns event counts in hourly buckets for the last 24 hours
     /// </summary>
-    List<TrendBucket> GetEventsLast24h();
+    List<TrendBucket> GetEventsLast24h(DateTime? now = null);
 
     /// <summary>
     /// Returns event counts in daily buckets for the last 7 days
     /// </summary>
-    List<TrendBucket> GetEventsLast7d();
+    List<TrendBucket> GetEventsLast7d(DateTime? now = null);
 }

--- a/server/MiniSOC.Server/Services/SqliteMetricsService.cs
+++ b/server/MiniSOC.Server/Services/SqliteMetricsService.cs
@@ -71,13 +71,13 @@ public class SqliteMetricsService : IMetricsService
     /// Returns event counts in hourly buckets for the last 24 hours (UTC).
     /// Buckets with no events return count 0.
     /// </summary>
-    public List<TrendBucket> GetEventsLast24h()
+    public List<TrendBucket> GetEventsLast24h(DateTime? now = null)
     {
+        var effectiveNow = now ?? DateTime.UtcNow;
         var result = new List<TrendBucket>();
         var dict = new Dictionary<string, int>();
 
-        var now = DateTime.UtcNow;
-        var end = new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc).AddHours(1);
+        var end = new DateTime(effectiveNow.Year, effectiveNow.Month, effectiveNow.Day, effectiveNow.Hour, 0, 0, DateTimeKind.Utc).AddHours(1);
         var start = end.AddHours(-24);
         
         using var connection = _database.GetConnection();
@@ -115,13 +115,13 @@ public class SqliteMetricsService : IMetricsService
     /// Returns event counts in daily buckets for the last 7 days (UTC).
     /// Buckets with no events return count 0.
     /// </summary>
-    public List<TrendBucket> GetEventsLast7d()
+    public List<TrendBucket> GetEventsLast7d(DateTime? now = null)
     {
         var result = new List<TrendBucket>();
         var dict = new Dictionary<string, int>();
 
-        var now = DateTime.UtcNow;
-        var end = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, DateTimeKind.Utc);
+        var effectiveNow = now ?? DateTime.UtcNow;
+        var end = new DateTime(effectiveNow.Year, effectiveNow.Month, effectiveNow.Day, 0, 0, 0, DateTimeKind.Utc);
         var start = end.AddDays(-7);
         
         using var connection = _database.GetConnection();


### PR DESCRIPTION
Removes internal DateTime.UtcNow calls from metrics service methods.

- GetEventsLast24h() and GetEventsLast7d() now accept optional DateTime? now parameter
- Production behavior unchanged (defaults to DateTime.UtcNow)
- Tests now use a fixed DateTime to avoid timing-dependent failures

Closes #41